### PR TITLE
Bump backup version for updated OWASP recommendation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -70,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   fixnum:
     dependency: transitive
     description:
@@ -115,28 +108,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -162,7 +155,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -190,21 +183,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   tuple:
     dependency: transitive
     description:

--- a/lib/stack_wallet_backup.dart
+++ b/lib/stack_wallet_backup.dart
@@ -52,12 +52,29 @@ List<VersionParameters> getAllVersions() {
   // Version 1 uses PBKDF2, XChaCha20-Poly1305, and Blake2b
   version = 1;
   aad = protocol + version.toString();
-  const int owaspRecommendedPbkdf2Sha512Iterations = 120000; // OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
+  const int owaspRecommendedPbkdf2Sha512IterationsVersion1 = 120000; // OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
   const int pbkdf2SaltLength = 16; // Take that, rainbow tables!
   versions.add(VersionParameters(
     version,
-    (passphrase) => _pbkdf2(passphrase, Uint8List.fromList(utf8.encode(aad)), Hmac.sha512(), owaspRecommendedPbkdf2Sha512Iterations, Xchacha20.poly1305Aead().secretKeyLength),
-    (adk, salt) => _pbkdf2(adk, salt, Hmac.sha512(), owaspRecommendedPbkdf2Sha512Iterations, Xchacha20.poly1305Aead().secretKeyLength),
+    (passphrase) => _pbkdf2(passphrase, Uint8List.fromList(utf8.encode(aad)), Hmac.sha512(), owaspRecommendedPbkdf2Sha512IterationsVersion1, Xchacha20.poly1305Aead().secretKeyLength),
+    (adk, salt) => _pbkdf2(adk, salt, Hmac.sha512(), owaspRecommendedPbkdf2Sha512IterationsVersion1, Xchacha20.poly1305Aead().secretKeyLength),
+    (key, nonce, plaintext) => _xChaCha20Poly1305Encrypt(key, nonce, plaintext, aad),
+    (key, blob) => _xChaCha20Poly1305Decrypt(key, blob, aad),
+    (data) => _blake2b(data, aad),
+    pbkdf2SaltLength,
+    Xchacha20.poly1305Aead().nonceLength,
+    Poly1305().macLength,
+    Blake2b().hashLengthInBytes 
+  ));
+
+  // Version 2 uses PBKDF2, XChaCha20-Poly1305, and Blake2b
+  version = 2;
+  aad = protocol + version.toString();
+  const int owaspRecommendedPbkdf2Sha512IterationsVersion2 = 210000; // OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
+  versions.add(VersionParameters(
+    version,
+    (passphrase) => _pbkdf2(passphrase, Uint8List.fromList(utf8.encode(aad)), Hmac.sha512(), owaspRecommendedPbkdf2Sha512IterationsVersion2, Xchacha20.poly1305Aead().secretKeyLength),
+    (adk, salt) => _pbkdf2(adk, salt, Hmac.sha512(), owaspRecommendedPbkdf2Sha512IterationsVersion2, Xchacha20.poly1305Aead().secretKeyLength),
     (key, nonce, plaintext) => _xChaCha20Poly1305Encrypt(key, nonce, plaintext, aad),
     (key, blob) => _xChaCha20Poly1305Decrypt(key, blob, aad),
     (data) => _blake2b(data, aad),

--- a/test/stack_wallet_backup_test.dart
+++ b/test/stack_wallet_backup_test.dart
@@ -99,7 +99,7 @@ void main() {
 
       // Compute ADK (this would be stored in the device enclave and, if needed, later retrived for decryption)
       // NOTE: The ADK will differ between protocol versions, so the version should be stored with it
-      final Tuple2<int, Uint8List> adkData = await generateAdk(passphrase);
+      final Tuple2<int, Uint8List> adkData = await generateAdk(passphrase, version: version);
       Uint8List adk = adkData.item2;
 
       // Encrypt
@@ -144,14 +144,14 @@ void main() {
       final Uint8List plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
 
       // Compute ADK
-      final Tuple2<int, Uint8List> adkData = await generateAdk(passphrase);
+      final Tuple2<int, Uint8List> adkData = await generateAdk(passphrase, version: version);
       Uint8List adk = adkData.item2;
 
       // Encrypt
       final Uint8List blob = await encryptWithAdk(adk, plaintextBytes, version: version);
 
       // Compute evil ADK
-      final Tuple2<int, Uint8List> evilAdkData = await generateAdk(evilPassphrase);
+      final Tuple2<int, Uint8List> evilAdkData = await generateAdk(evilPassphrase, version: version);
       Uint8List evilAdk = evilAdkData.item2;
 
       // Decrypt with an evil ADK
@@ -193,7 +193,7 @@ void main() {
       final Uint8List plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
 
       // Compute ADK
-      final Tuple2<int, Uint8List> adkData = await generateAdk(passphrase);
+      final Tuple2<int, Uint8List> adkData = await generateAdk(passphrase, version: version);
       Uint8List adk = adkData.item2;
 
       // Encrypt twice to simulate multiple backups; we even use the same plaintext!


### PR DESCRIPTION
Bumps the backup version to account for updated [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2) for `PBKDF2` key derivation.

Fixes ADK-related tests that weren't accounting for new versions.