### PR TITLE
Add function parameter type

### DIFF
--- a/lib/secure_storage.dart
+++ b/lib/secure_storage.dart
@@ -178,7 +178,7 @@ class StorageCryptoHandler {
   }
 
   /// Reset the passphrase, which resets the salt and main key
-  Future<void> resetPassphrase(String passphrase, version) async {
+  Future<void> resetPassphrase(String passphrase, int version) async {
     // Generate a random salt
     _salt = _randomBytes(saltLength);
 


### PR DESCRIPTION
Requires that secure storage versions be integers, which wasn't specifically enforced during password reset. Dynamic typing is silly.